### PR TITLE
use explicitly nullable parameter types (implicit deprecated in php 8.4)

### DIFF
--- a/AmqpConsumer.php
+++ b/AmqpConsumer.php
@@ -48,7 +48,7 @@ class AmqpConsumer implements InteropAmqpConsumer
         $this->flags = self::FLAG_NOPARAM;
     }
 
-    public function setConsumerTag(string $consumerTag = null): void
+    public function setConsumerTag(?string $consumerTag = null): void
     {
         $this->consumerTag = $consumerTag;
     }

--- a/AmqpProducer.php
+++ b/AmqpProducer.php
@@ -79,7 +79,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setDeliveryDelay(int $deliveryDelay = null): Producer
+    public function setDeliveryDelay(?int $deliveryDelay = null): Producer
     {
         if (null === $this->delayStrategy) {
             throw DeliveryDelayNotSupportedException::providerDoestNotSupportIt();
@@ -98,7 +98,7 @@ class AmqpProducer implements InteropAmqpProducer, DelayStrategyAware
     /**
      * @return self
      */
-    public function setPriority(int $priority = null): Producer
+    public function setPriority(?int $priority = null): Producer
     {
         $this->priority = $priority;
 


### PR DESCRIPTION
> PHP supports nullable type declarations as of PHP 7.1 with the [?T syntax](https://wiki.php.net/rfc/nullable_types), and with the [T|null syntax](https://wiki.php.net/rfc/union_types_v2) as of PHP 8.0 when generalized support for union types was added.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

This package declares to require php ^7.4 || ^8.0, therefore the ?T syntax is used here.

I believe that all those parameters dont actually need a default value, but I leave that out because it might be BC if someone is actually calling those settings with no params.